### PR TITLE
chore(zsh): 生成物・環境依存ファイルを gitignore に追加

### DIFF
--- a/.config/zsh/.gitignore
+++ b/.config/zsh/.gitignore
@@ -4,3 +4,7 @@
 !.zfunc/.gitkeep
 .zkbd/
 .zshenv
+.zprofile
+.zcompcache/
+.zsh_history
+.zsh_sessions/


### PR DESCRIPTION
## 概要

`.config/zsh/` 以下で追跡漏れしていた生成物・環境依存ファイルを `.gitignore` に追加する。

## 追加した除外パターン

- `.zprofile` — OrbStack が自動挿入する環境固有の初期化（既に ignore 済みの `.zshenv` と同じ扱い）
- `.zcompcache/` — 補完キャッシュ（`brew_all_commands` 等の生成物）
- `.zsh_history` — コマンド履歴
- `.zsh_sessions/` — macOS のセッション情報

いずれも生成物・環境依存で、追跡すべき設定は含まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)